### PR TITLE
more bugfixes related to removing superfluous information for .tif files

### DIFF
--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -11,17 +11,14 @@ configfile: "tomancak_czi.json"
 
 padding_format = "{0:0"+str(padding_of_file_id(int(config["common"]["ntimepoints"])))+"d}"
 ds_format = "-"+padding_format+"-00.h5"
+
 # problematic needs padding of file_id
 datasets = [ str(config["common"]["hdf5_xml_filename"].strip('\"')+(ds_format.format(item))) for item in range(int(config["common"]["ntimepoints"])) ]
 
 xml_merge_in = produce_xml_merge_job_files(datasets)
 
 rule done:
-    #input: [ ds+"_fusion" for ds in datasets ]
-    #input: [ ds + "_" + config["common"]["fusion_switch"] for ds in datasets ]
-    #input: config["hdf5_output"]["output_xml"] + ".xml"
     input: [ ds + "_output_hdf5" for ds in datasets ]
-    #input: config["hdf5_output"]["output_xml"].strip('\"') + ".xml"
     
 rule resave_prepared:
     input: expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"] ], suffix=["xml","h5"])
@@ -377,7 +374,7 @@ rule deconvolution:
 rule define_output:
     input: [ item + "_" + config["common"]["fusion_switch"] for item in datasets ], glob.glob('TP*')
     output: config["hdf5_output"]["output_xml"].strip('\"') + ".xml"
-    log: "define_xml_tif.log"
+    log: "define_output.log"
     run:
         cmd_string = produce_string(
         	"""{fiji-prefix} {fiji-app} \

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -58,7 +58,7 @@ rule define_xml_czi:
         
 # defining xml for tif dataset
 rule define_xml_tif:
-    input: glob.glob('*.tif')
+    input: glob.glob(re.sub("{{.}}","*",config["define_xml_tif"]['image_file_pattern'])) #replaces all occurrences of {{a}} (a can be any character) by * to use the string for globbing
     output: config["common"]["first_xml_filename"] + ".xml"
     log: "define_xml_tif.log"
     run:

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -85,7 +85,7 @@ rule define_xml_tif:
 	   config["define_xml_tif"],
 	   jdir=JOBDIR,
 	   path_bsh=config["common"]["bsh_directory"] + config["define_xml_tif"]["bsh_file"],
-           timepoints="1-"+str(config["common"]["ntimepoints"])
+           timepoints="0-"+str(int(config["common"]["ntimepoints"])-1)
         )
 	
 	cmd_string +=" > {log} 2>&1"

--- a/spim_registration/timelapse/tomancak_test_cluster.json
+++ b/spim_registration/timelapse/tomancak_test_cluster.json
@@ -51,7 +51,6 @@
     
     "resave_hdf5" :
     {
-    	    "parallel_timepoints" : "5",
     	    "resave_angle" : "\"All angles\"",
     	    "resave_channel" : "\"All channels\"",
     	    "resave_illumination" : "\"All illuminations\"",

--- a/spim_registration/timelapse/tomancak_test_cluster.json
+++ b/spim_registration/timelapse/tomancak_test_cluster.json
@@ -5,7 +5,7 @@
 	"fiji-prefix" : "/sw/bin/xvfb-run -a",
 	"directory_cuda" : "/lustre/projects/hpcsupport/steinbac/unicore/christopher/unicore_jobs/Fiji.app.cuda_new/lib/",
 	"merged_xml" : "hdf5_test_unicore_merge",
-	"bsh_directory" : "/home/steinbac/development/cschmied-snakemake-workflows/spim_registration/timelapse/",
+	"bsh_directory" : "/home/steinbac/development/schmied-snakemake-workflows/spim_registration/timelapse/",
 	"first_xml_filename" : "test_unicore",
 	"hdf5_xml_filename" : "\"hdf5_test_unicore\"",
 	"fusion_switch" : "deconvolution",
@@ -33,7 +33,6 @@
     
     "define_xml_tif" :
     {
-	"timepoints" : "0-4",
 	"acquisition_angles" : "0,72,144,216,288",
 	"channels" : "0",
 	"image_file_pattern" : "img_TL{{t}}_Angle{{a}}.tif",


### PR DESCRIPTION
I'll suggest to merge schmiedc/snakemake-workflow@adding_resave to schmiedc/snakemake-workflow@master so we can work on branches that have a descriptive name ... not an outdated one ;)
